### PR TITLE
Hide {} in error message from formatting machinery

### DIFF
--- a/src/operations/apply.rs
+++ b/src/operations/apply.rs
@@ -194,7 +194,9 @@ pub fn apply(
     let shell = config.shell.unwrap_or_else(|| "sh -c '{}'".into());
 
     if !shell.contains("{}") {
-        return Err(anyhow!("The configured shell does not contain the required command placeholder '{}'. Check the default file or github for config examples."));
+        // Hide {} in this error message from the formatting machinery in anyhow macro
+        let msg = "The configured shell does not contain the required command placeholder '{}'. Check the default file or github for config examples.";
+        return Err(anyhow!(msg));
     }
 
     let mut hooks = Vec::new();


### PR DESCRIPTION
I am looking into resolving https://github.com/dtolnay/anyhow/issues/55 and this looks like the single crate on crates.io where "{}" is used intentionally in an error message &mdash; meanwhile there were a couple dozen where it's a bug where they forgot to pass a second argument that was supposed to be interpolated in the message.

If you are open to tweaking this code, I'll land a fix for https://github.com/dtolnay/anyhow/issues/55 to help others catch missed format arguments.