### PR TITLE
feat: look for schemes and templates in config dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ Let me know if you want to package flavours for your favorite distro.
 Just install cargo and run `cargo install --locked flavours` (don't forget to include `~/.cargo/bin` on your PATH).
 
 #### Post-install
-After installing, you should probably use `flavours update all` to grab all published schemes and templates from the base16 repos. If you want, you can manually tweak the templates, schemes or even the repo lists (everything's located in `~/.local/share/flavours` on Linux, and can be changed with `-d`/`--directory` cli option or `FLAVOURS_DATA_DIRECTORY` environment variable).
+After installing, you should probably use `flavours update all` to grab all published schemes and templates from the base16 repos. This will download all the available schemes and templates to `~/.local/share/flavours` on Linux, and can be changed with `-d`/`--directory` cli option or `FLAVOURS_DATA_DIRECTORY` environment variable.
+
+If you want to make changes to schemes/templates or make your own, see [Custom templates and schemes](#custom-templates-and-schemes).
 
 ### Usage
 You can use flavours and base16 templates to automatically inject schemes into any application config file that supports colors codes.
@@ -104,6 +106,16 @@ end = "/* End flavours */"
 ```
 
 Vóila. You're now ready to apply schemes.
+
+#### Custom templates and schemes
+
+To help manage your custom templates/schemes or your tweaks to pre-existing ones, flavours will also look in the user's `$XDG_CONFIG_HOME/flavours` directory, typically `~/.config/flavours`, when looking for templates/schemes. The folder structure should be the same as at `~/.local/share/flavours/base16/`.
+
+Examples:
+* Custom scheme `myscheme`: `$XDG_CONFIG_HOME/flavours/schemes/myscheme/myscheme.yaml`
+* Custom template `mysoftware/mytemplate`: `$XDG_CONFIG_HOME/flavours/templates/mysoftware/templates/mytemplate.mustache`
+
+Note, in case of conflict, schemes/templates in `$XDG_CONFIG_HOME/flavours` have priority over the ones in `${FLAVOURS_DATA_DIRECTORY:-~/.local/share/flavours}`.
 
 #### Applying
 `flavours apply` is the command you'll probably be using all the time. So it's built to be as useful as possible.

--- a/src/find.rs
+++ b/src/find.rs
@@ -1,24 +1,63 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use glob::glob;
 use path::{Path, PathBuf};
 use std::path;
 
-/// Find function
+/// Find color schemes matching pattern in either the config dir or the data dir.
 ///
 /// * `pattern` - Which pattern to use
-/// * `schemes_dir` - Schemes directory
-pub fn find(pattern: &str, schemes_dir: &Path) -> Result<Vec<PathBuf>> {
-    let dir = schemes_dir
-        .to_str()
-        .ok_or_else(|| anyhow!("Unable to convert path"))?;
-
-    let pattern = format!("{}/*/{}.y*ml", dir, pattern);
-    let matches = glob(&pattern)?;
+/// * `base_dir` - flavours' base data dir
+/// * `config_dir` - flavours' config dir
+pub fn find_schemes(pattern: &str, base_dir: &Path, config_dir: &Path) -> Result<Vec<PathBuf>> {
+    let config_scheme_dir = config_dir.join("schemes");
+    let data_scheme_dir = base_dir.join("base16").join("schemes");
+    let dir_vec = vec![config_scheme_dir, data_scheme_dir];
+    let dir_vec: Vec<&str> = dir_vec.iter().filter_map(|dir| dir.to_str()).collect();
 
     let mut found = Vec::new();
-    for element in matches {
-        found.push(element?);
+    for dir in dir_vec {
+        let glob_pattern = format!("{}/*/{}.y*ml", dir, pattern);
+        let matches = glob(&glob_pattern)?;
+        for element in matches {
+            found.push(element?);
+        }
     }
-
     Ok(found)
+}
+
+/// Find template file in either the config dir or the data dir.
+///
+/// * `template` - template
+/// * `subtemplate` - subtemplate
+/// * `base_dir` - flavours' base data dir
+/// * `config_dir` - flavours' config dir
+pub fn find_template(
+    template: &str,
+    subtemplate: &str,
+    base_dir: &Path,
+    config_dir: &Path,
+) -> Result<PathBuf> {
+    let template_config_file = config_dir
+        .join("templates")
+        .join(&template)
+        .join("templates")
+        .join(format!("{}.mustache", subtemplate));
+
+    let template_data_file = base_dir
+        .join("base16")
+        .join("templates")
+        .join(&template)
+        .join("templates")
+        .join(format!("{}.mustache", subtemplate));
+
+    if template_config_file.is_file() {
+        Ok(template_config_file)
+    } else if template_data_file.is_file() {
+        Ok(template_data_file)
+    } else {
+        panic!(
+            "Neither {:?} or {:?} exist",
+            template_config_file, template_data_file
+        )
+    }
 }

--- a/src/operations/build.rs
+++ b/src/operations/build.rs
@@ -18,7 +18,7 @@ pub fn build_template(template_base: String, scheme: &Scheme) -> Result<String> 
         .replace("{{scheme-slug}}", &scheme.slug);
 
     for (name, color) in scheme.colors.iter().enumerate() {
-        let hex = String::from(color).replace("#", "");
+        let hex = String::from(color).replace('#', "");
         let rgb = hex::decode(&hex)?;
         built_template = built_template
             .replace(

--- a/src/operations/info.rs
+++ b/src/operations/info.rs
@@ -3,7 +3,7 @@ use calm_io::stdoutln;
 use std::fs::read_to_string;
 use std::path::Path;
 
-use crate::find::find;
+use crate::find::find_schemes;
 use crate::scheme::Scheme;
 
 fn true_color(hex_color: &str, background: bool) -> Result<String> {
@@ -40,10 +40,10 @@ pub fn print_color(color: &str) -> Result<()> {
 /// * `base_dir` - flavours base data dir
 /// * `verbose` - Should we be verbose? (unused)
 /// * `color` - Should we print with colors?
-pub fn info(patterns: Vec<&str>, base_dir: &Path, raw: bool) -> Result<()> {
+pub fn info(patterns: Vec<&str>, base_dir: &Path, config_dir: &Path, raw: bool) -> Result<()> {
     let mut schemes = Vec::new();
     for pattern in patterns {
-        let found_schemes = find(pattern, &base_dir.join("base16").join("schemes"))?;
+        let found_schemes = find_schemes(pattern, base_dir, config_dir)?;
 
         for found_scheme in found_schemes {
             schemes.push(found_scheme);

--- a/src/operations/list.rs
+++ b/src/operations/list.rs
@@ -1,18 +1,25 @@
 use anyhow::{anyhow, Result};
 use std::path::Path;
 
-use crate::find::find;
+use crate::find::find_schemes;
 
 /// List subcommand
 ///
 /// * `patterns` - Vector with patterns
-/// * `base_dir` - flavours base data dir
+/// * `base_dir` - flavours' base data dir
+/// * `config_dir` - flavours' config dir
 /// * `verbose` - Should we be verbose? (unused)
 /// * `lines` - Should we print each scheme on its own line?
-pub fn list(patterns: Vec<&str>, base_dir: &Path, _verbose: bool, lines: bool) -> Result<()> {
+pub fn list(
+    patterns: Vec<&str>,
+    base_dir: &Path,
+    config_dir: &Path,
+    _verbose: bool,
+    lines: bool,
+) -> Result<()> {
     let mut schemes = Vec::new();
     for pattern in patterns {
-        let found_schemes = find(pattern, &base_dir.join("base16").join("schemes"))?;
+        let found_schemes = find_schemes(pattern, base_dir, config_dir)?;
 
         for found_scheme in found_schemes {
             schemes.push(String::from(


### PR DESCRIPTION
Hi !

I was having trouble with my custom templates getting overwritten when using `flavours update all` so I made some changes so that custom templates can live somewhere else and don't get destroyed when updating.

In short, `flavours` will also look for schemes & templates in the user's config dir, e.g.:
* scheme: `~/.config/flavours/schemes/myscheme/myscheme.yaml`
* template: `~/.config/flavours/templates/mysoftware/templates/mytemplate.mustache`

Added bonus, the custom schemes/templates can more easily be packaged/managed with my other dot files !

I haven't tested it very thoroughly but do with this what you will :)