### PR TITLE
Configurable sources (and source hierarchy)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,10 @@ use std::path::Path;
 #[derive(Deserialize, Debug)]
 pub struct Config {
     pub shell: Option<String>,
+    pub schemes: Option<String>,
+    pub templates: Option<String>,
+    pub extra_schemes: Option<Vec<String>>,
+    pub extra_templates: Option<Vec<String>>,
     pub item: Option<Vec<ConfigItem>>,
     pub items: Option<Vec<ConfigItem>>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,10 +8,17 @@ pub struct Config {
     pub shell: Option<String>,
     pub schemes: Option<String>,
     pub templates: Option<String>,
-    pub extra_schemes: Option<Vec<String>>,
-    pub extra_templates: Option<Vec<String>>,
+    pub extra_scheme: Option<Vec<ExtraSource>>,
+    pub extra_template: Option<Vec<ExtraSource>>,
     pub item: Option<Vec<ConfigItem>>,
     pub items: Option<Vec<ConfigItem>>,
+}
+
+/// Structure for configuration extra sources
+#[derive(Deserialize, Debug)]
+pub struct ExtraSource{
+    pub name: String,
+    pub source: String,
 }
 
 /// Structure for configuration apply items

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,7 +123,12 @@ fn main() -> Result<()> {
             let operation = sub_matches
                 .value_of("operation")
                 .ok_or_else(|| anyhow!("Invalid operation"))?;
-            update::update(operation, &flavours_dir, verbose)
+            update::update(
+                operation,
+                &flavours_dir,
+                verbose,
+                &flavours_config
+            )
         }
 
         Some(("info", sub_matches)) => {

--- a/src/operations/update.rs
+++ b/src/operations/update.rs
@@ -1,11 +1,13 @@
 use std::env::set_var;
-use std::fs::{create_dir_all, remove_dir_all, write, File};
+use std::fs::{create_dir_all, remove_dir_all, write, File, read_to_string};
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::process::Command;
 use std::thread::spawn;
 
 use anyhow::{anyhow, Context, Result};
+use crate::config::Config;
+
 
 ///Parses yml line containing name and repository link
 ///
@@ -34,10 +36,26 @@ fn write_sources(s_repo: &str, t_repo: &str, file: &Path) -> Result<()> {
 ///
 ///# Arguments
 ///* `file` - Path to sources file
-fn get_sources(file: &Path) -> Result<(String, String)> {
+fn get_sources(file: &Path, config_path: &Path) -> Result<(String, String)> {
     // Default repos
     let default_s_repo = "https://github.com/chriskempson/base16-schemes-source.git";
     let default_t_repo = "https://github.com/chriskempson/base16-templates-source.git";
+
+    let config_contents = read_to_string(config_path)
+        .with_context(|| format!("Couldn't read configuration file {:?}.", config_path))?;
+
+    let config = Config::read(&config_contents, config_path)?;
+
+    // check if config sources exist
+    let schemes = match config.schemes {
+        Some(value) => String::from(value),
+        None => String::from("default"),
+    };
+
+    let templates = match config.templates {
+        Some(value) => String::from(value),
+        None => String::from("default"),
+    };
 
     // Try to open file
     let sources_file = match File::open(file) {
@@ -46,7 +64,12 @@ fn get_sources(file: &Path) -> Result<(String, String)> {
         // Handle error once, so if file is not found it can be created
         Err(_) => {
             // Try to write default repos to file
-            write_sources(default_s_repo, default_t_repo, file)?;
+            match (schemes.as_str(), templates.as_str()) {
+                ("default", "default") => write_sources(default_s_repo, default_t_repo, file)?,
+                (_, "default") => write_sources(&schemes, default_t_repo, file)?,
+                ("default", _) => write_sources(default_s_repo, &templates, file)?,
+                (_, _) => write_sources(&schemes, &templates, file)?,
+            };
             // Try to open it again, returns errors if unsucessful again
             File::open(file).with_context(|| format!("Couldn't access {:?}", file))?
         }
@@ -196,14 +219,21 @@ fn git_clone(path: &Path, repo: String, verbose: bool, clone_type: CloneType) ->
     }
 }
 
-fn update_lists(dir: &Path, verbose: bool) -> Result<()> {
+fn update_lists(
+    dir: &Path,
+    verbose: bool,
+    config_path: &Path
+) -> Result<()> {
     let sources_dir = &dir.join("sources");
     if verbose {
         println!("Updating sources list from sources.yaml")
     }
 
     // Get schemes and templates repository from file
-    let (schemes_source, templates_source) = get_sources(&dir.join("sources.yaml"))?;
+    let (schemes_source, templates_source) = get_sources(
+            &dir.join("sources.yaml"),
+            config_path
+    )?;
     if verbose {
         println!("Schemes source: {}", schemes_source);
         println!("Templates source: {}", templates_source);
@@ -305,15 +335,20 @@ fn update_templates(dir: &Path, verbose: bool) -> Result<()> {
 ///* `operation` - Which operation to do
 ///* `dir` - The base path to be used
 ///* `verbose` - Boolean, be verbose if true
-pub fn update(operation: &str, dir: &Path, verbose: bool) -> Result<()> {
+pub fn update(
+    operation: &str,
+    dir: &Path,
+    verbose: bool,
+    config_path: &Path
+) -> Result<()> {
     let base16_dir = &dir.join("base16");
     create_dir_all(base16_dir)?;
     match operation {
-        "lists" => update_lists(base16_dir, verbose),
+        "lists" => update_lists(base16_dir, verbose, config_path),
         "schemes" => update_schemes(base16_dir, verbose),
         "templates" => update_templates(base16_dir, verbose),
         "all" => {
-            update_lists(base16_dir, verbose)?;
+            update_lists(base16_dir, verbose, config_path)?;
             update_schemes(base16_dir, verbose)?;
             update_templates(base16_dir, verbose)
         }


### PR DESCRIPTION
It appears a few people want support for configurable sources. As I mentioned in my previously closed [pr](https://github.com/Misterio77/flavours/pull/61) I was thinking of doing so, I believe this is a more proper solution than my last pr but this is still my first time writing rust so I would review my additions if you're interested in this feature.

## Configuration Hierarchy
The `config.toml` source lists take precedence over `~/.local/share/flavours/base16/sources.yaml` and `~/.local/share/flavours/base16/sources.yaml` takes precedence over the default source lists.

## Configuration Schema
The `config.toml` now supports configuring source lists and extra sources.

```rust
/// Structure for configuration
#[derive(Deserialize, Debug)]
pub struct Config {
    pub shell: Option<String>,
    pub schemes: Option<String>,
    pub templates: Option<String>,
    pub extra_scheme: Option<Vec<ExtraSource>>,
    pub extra_template: Option<Vec<ExtraSource>>,
    pub item: Option<Vec<ConfigItem>>,
    pub items: Option<Vec<ConfigItem>>,
}
```

* `schemes`: is a string of the link to a repo of a list of schemes of [this format](https://github.com/chriskempson/base16-schemes-source)
* `templates`: is a string of the link to a repo of a list of templates of [this format](https://github.com/chriskempson/base16-templates-source)
* `extra_scheme`: is a vector of extra schemes. Each extra scheme is added to the appropriate `list.yaml`, maintaining sorted order.
* `extra_template`: is a vector of extra templates. Each extra scheme is added to the appropriate `list.yaml`, maintaining sorted order.

### Extra Schemes and Templates
In the case where a user would like to configure schemes and templates that are not included in their active source lists they may provide extra schemes and templates that will be inserted into the appropriate `list.yaml` file. The `Config` struct fields `extra_scheme` and `extra_template` are vectors of the following extra source structure.

```rust
/// Structure for configuration extra sources
#[derive(Deserialize, Debug)]
pub struct ExtraSource{
    pub name: String,
    pub source: String,
}
```

* `name`: is a string of the name of the scheme or template, the key to the sources in the `list.yaml` files.
* `source`: is a string of a link to a base16 [scheme](https://github.com/chriskempson/base16-default-schemes) or [template](https://github.com/aarowill/base16-alacritty) repo of the respective linked format. The source appears as the value to the source name in the `list.yaml` files.

### Example
I've attached a simple `config.toml` that shows the new features with some snippets of the resulting files after running `flavours update all`.

```toml
# config.toml
schemes = "https://github.com/Softsun2/base16-schemes-source"
# templates = "my-templates"

[[extra_scheme]]
name = "tarko"
source = "https://github.com/Softsun2/base16-tarko-scheme"
``` 

Here I'm choosing to use a non-default scheme list, the default template list, and an extra scheme that's not included in the scheme list I've configured.

```yaml
# ~/.local/share/flavours/base16/sources.yaml
schemes: https://github.com/Softsun2/base16-schemes-source
templates: https://github.com/chriskempson/base16-templates-source.git
```

You can see that the configured source list was written as expected.

```yaml
# ~/.local/share/flavours/base16/sources/schemes/list.yaml
...
synth-midnight: https://github.com/michael-ball/base16-synth-midnight-scheme
tango: https://github.com/Schnouki/base16-tango-scheme
tarko: https://github.com/Softsun2/base16-tarko-scheme
tender: https://github.com/DanManN/base16-tender-scheme
twilight: https://github.com/hartbit/base16-twilight-scheme
...
```

This is a snippet of the schemes list yaml file. Just shows that the extra scheme (tarko) made it's way into the list of schemes.

## Notes
I haven't really tested this much, I plan on using this fork of flavours, I'll report/fix bugs I run into. I have zero rust experience, so I would review my changes closely if this is a feature you would like to implement.