### PR TITLE
feat: select subtemplate based on the scheme used

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For the flavours configuration file, `config.toml`:
 - Create an `[[items]]` section for each app. Each section can have the following entries:
   - The `file` to write (required).
   - A `template` (required).
-  - A `subtemplate`. Defaults to `default`.
+  - A `subtemplate`. You can use the literal value `{scheme}` to select a subtemplate named the same way as a scheme, usefull if you have scheme dependent subtemplates. Defaults to `default` (also if a subtemplate named as the selected scheme isn't found).
   - A `hook` to execute. Defaults to none.
   - Specified as `light`, for lightweight changes that are quick to execute. Defaults to `true`. `flavours apply --light` will skip running hooks marked with `light=false`.
   - Whether to `rewrite` the entire file instead of replacing lines. Defaults to `false`, but it is recommended to set this to true for apps that can have an entire file defining colors through import or some other means.

--- a/src/find.rs
+++ b/src/find.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use glob::glob;
 use path::{Path, PathBuf};
 use std::path;
@@ -55,9 +55,11 @@ pub fn find_template(
     } else if template_data_file.is_file() {
         Ok(template_data_file)
     } else {
-        panic!(
-            "Neither {:?} or {:?} exist",
-            template_config_file, template_data_file
+        return Err(
+            anyhow!(
+                "Neither {:?} or {:?} exist",
+                template_config_file, template_data_file
+            )
         )
     }
 }

--- a/src/operations/apply.rs
+++ b/src/operations/apply.rs
@@ -215,12 +215,15 @@ pub fn apply(
         //Template name
         let template = &item.template;
         //Subtemplate name
-        let subtemplate_scheme = find_template(template, &scheme.name, base_dir, config_dir);
-        let subtemplate = match subtemplate_scheme {
-            Ok(_value) => scheme.name.clone(),
-            Err(_e) => match &item.subtemplate {
-                Some(value) => String::from(value),
-                None => String::from("default"),
+        let mut subtemplate = match &item.subtemplate {
+            Some(value) => String::from(value),
+            None => String::from("default"),
+        };
+        if subtemplate == "{scheme}" {
+            let subtemplate_scheme = find_template(template, &scheme.name, base_dir, config_dir);
+            subtemplate = match subtemplate_scheme {
+                Ok(_value) => scheme.name.clone(),
+                Err(_e) => String::from("default"),
             }
         };
         //Is the hook lightweight?

--- a/src/operations/apply.rs
+++ b/src/operations/apply.rs
@@ -215,9 +215,13 @@ pub fn apply(
         //Template name
         let template = &item.template;
         //Subtemplate name
-        let subtemplate = match &item.subtemplate {
-            Some(value) => String::from(value),
-            None => String::from("default"),
+        let subtemplate_scheme = find_template(template, &scheme.name, base_dir, config_dir);
+        let subtemplate = match subtemplate_scheme {
+            Ok(_value) => scheme.name.clone(),
+            Err(_e) => match &item.subtemplate {
+                Some(value) => String::from(value),
+                None => String::from("default"),
+            }
         };
         //Is the hook lightweight?
         let light = match &item.light {


### PR DESCRIPTION
Solves #65. It is not ideal, since I call `find_template` twice, but it gets the job done. I could change the `find_template` function to also receive the scheme as a parameter and give that back if a subtemplate with the scheme name is found, but well I'd like to first hear from you :)