### PR TITLE
Add list templates

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,6 +61,12 @@ pub fn build_cli() -> App<'static> {
                 .setting(AppSettings::DisableVersionFlag)
                 .setting(AppSettings::ColoredHelp)
                 .arg(
+                    Arg::new("templates")
+                    .about("list available patterns")
+                    .long("templates")
+                    .short('t')
+                )
+                .arg(
                     Arg::new("pattern")
                     .about("Scheme name or glob pattern to match when listing scheme(s). If ommited, defaults to * (all installed schemes).")
                     .setting(ArgSettings::MultipleValues)

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::convert::TryInto;
 use std::env;
 use std::path::Path;
 
-use flavours::operations::{apply, build, current, generate, info, list, update};
+use flavours::operations::{apply, build, current, generate, info, list, list_templates, update};
 use flavours::{cli, completions};
 
 use std::fs::{create_dir_all, write};
@@ -115,13 +115,24 @@ fn main() -> Result<()> {
                 None => vec!["*"],
             };
             let lines = sub_matches.is_present("lines");
-            list::list(
-                patterns,
-                &flavours_dir,
-                &flavours_config_dir,
-                verbose,
-                lines,
-            )
+
+            if sub_matches.is_present("templates") {
+                list_templates::list(
+                    patterns,
+                    &flavours_dir,
+                    &flavours_config_dir,
+                    verbose,
+                    lines,
+                )
+            } else {
+                list::list(
+                    patterns,
+                    &flavours_dir,
+                    &flavours_config_dir,
+                    verbose,
+                    lines,
+                )
+            }
         }
 
         Some(("update", sub_matches)) => {

--- a/src/operations/list_templates.rs
+++ b/src/operations/list_templates.rs
@@ -1,0 +1,62 @@
+use anyhow::{anyhow, Result};
+use std::path::Path;
+
+use crate::find::find_templates;
+
+/// List subcommand
+///
+/// * `patterns` - Vector with patterns
+/// * `base_dir` - flavours' base data dir
+/// * `config_dir` - flavours' config dir
+/// * `verbose` - Should we be verbose? (unused)
+/// * `lines` - Should we print each scheme on its own line?
+pub fn list(
+    patterns: Vec<&str>,
+    base_dir: &Path,
+    config_dir: &Path,
+    _verbose: bool,
+    lines: bool,
+) -> Result<()> {
+    let mut templates = Vec::new();
+    for pattern in patterns {
+        let found_templates = find_templates(pattern, base_dir, config_dir)?;
+        for found_template in found_templates {
+            templates.push(found_template
+                           .strip_prefix(base_dir)
+                           .map_or_else(
+                               |_| found_template.strip_prefix(config_dir),
+                               |path| path.strip_prefix("base16/"),
+                               )
+                           .map_err(|_| anyhow!("Couldn't get template name"))?
+                           .to_str()
+                           .ok_or_else(|| anyhow!("Couldn't convert name"))?
+                           .replacen("templates/", "", 2)
+                           .replace(".mustache","")
+                           );
+        }
+    }
+    templates.sort();
+    templates.dedup();
+
+    if templates.is_empty() {
+        return Err(anyhow!("No matching template found"));
+    };
+
+    for template in &templates {
+        // Print template
+        print!("{}", template);
+        if lines {
+            // Print newline
+            println!();
+        } else {
+            // Print space
+            print!(" ");
+        }
+    }
+    // If we separated by spaces, print an ending newline
+    if !lines {
+        println!();
+    }
+
+    Ok(())
+}

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -4,4 +4,5 @@ pub mod current;
 pub mod generate;
 pub mod info;
 pub mod list;
+pub mod list_templates;
 pub mod update;


### PR DESCRIPTION
Adds the ability to list templates (enhancement #35 ) using a flag with tthe existing `flavours list` command. 
example usage is shown below
```shell
❱ flavours list --templates
alacritty amfora binary-ninja blink ...
```
globbing still works, and `-t` works as short for `--templates` as you'd expect
```
❱ flavours list -t "i3*"
i3 i3status i3status-rust
```

including the '/templates/' (or just '/' as shown later) lists subtemplates
```
❱ flavours list -t "i3*/templates/*"
i3/bar-colors i3/client-properties i3/colors i3/default i3/nebi3 i3status-rust/default i3status/default
```
_note adding the .mustache extension to the end of the glob will produce the same output and is therefore optional_
_also note that the intermediary '/templates/' is NOT included in the output. This was done on purpose to make it easier to read, however I can imagine it causing some confusion because the output doesn't represent the actual file structure. I'm happy to figure out a different solution if this is a concern_

To make it easier I made it so globs with a single '/' have the slash expanded to '/templates/' . 
```
❱ flavours list -t "i3*/*"
i3/bar-colors i3/client-properties i3/colors i3/default i3/nebi3 i3status-rust/default i3status/default
```